### PR TITLE
Ember Data Errors

### DIFF
--- a/packages/ember-easyForm/lib/views/input.js
+++ b/packages/ember-easyForm/lib/views/input.js
@@ -6,7 +6,7 @@ Ember.EasyForm.Input = Ember.EasyForm.BaseView.extend({
     if (!this.isBlock) {
       this.set('template', Ember.Handlebars.compile(this.fieldsForInput()));
     }
-    if(this.get('context').get('errors')) {
+    if (!Ember.isNone(this.get('context.errors'))) {
       this.reopen({
         error: function() {
           return this.get('context').get('errors').get(this.property) !== undefined;


### PR DESCRIPTION
When using the latest ember-data and latest easyForm, both built from master, I get the following error:

```
Uncaught TypeError: Cannot call method 'get' of null ember-easyForm.js:305
```

EasyForm checks if errors is undefined but DS.Model is initialised with errors as null.

```
DS.Model = Ember.Object.extend(Ember.Evented, LoadPromise, {
  ...
  errors: null,
  ...
});
```

Checking if errors is truthy seems to solve the issue for me and all tests still pass. Not sure how this will affect ember-validations.
#14
