### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ be used as blocks such as:
 {{#input firstName}}
   {{inputField firstName}}{{labelField firstName}}
   <br/>
-  {{erroField firstName}}
+  {{errorField firstName}}
 {{/input}}
 ```
 


### PR DESCRIPTION
Just a little typo in the examples presented in README
