### PR TITLE
The FieldErrorClass was not being set. [Fixes #30]

### DIFF
--- a/packages/ember-easyForm/lib/views/input.js
+++ b/packages/ember-easyForm/lib/views/input.js
@@ -6,13 +6,12 @@ Ember.EasyForm.Input = Ember.EasyForm.BaseView.extend({
     if (!this.isBlock) {
       this.set('template', Ember.Handlebars.compile(this.fieldsForInput()));
     }
-    if (!Ember.isNone(this.get('context.errors'))) {
-      this.reopen({
-        error: function() {
-          return this.get('context').get('errors').get(this.property) !== undefined;
-        }.property('context.errors.'+this.property)
-      });
-    }
+
+    this.reopen({
+      error: function() {
+        return !Ember.isNone(this.get('context.errors.' + this.property));
+      }.property('context.errors.'+this.property)
+    });
   },
   tagName: 'div',
   classNames: ['string'],

--- a/packages/ember-easyForm/tests/helpers/input_test.js
+++ b/packages/ember-easyForm/tests/helpers/input_test.js
@@ -184,3 +184,20 @@ test('passes the inputConfig to the input field', function() {
   equal(textarea.attr('class'), 'ember-view ember-text-area span5');
   equal(textarea.attr('rows'), '2');
 });
+
+test('sets errors in models created without the "errors" object', function(){
+  delete model.errors;
+
+  view = Ember.View.create({
+    template: templateFor('{{input firstName}}'),
+    controller: controller
+  });
+  append(view);
+  ok(!view.$().find('div.fieldWithErrors').get(0));
+  ok(!view.$().find('span.error').get(0));
+  Ember.run(function() {
+    model.set('errors', {firstName: 'Some error!'});
+  });
+  ok(view.$().find('div.fieldWithErrors').get(0));
+  equal(view.$().find('span.error').text(), 'Some error!');
+});


### PR DESCRIPTION
Allow models created without the 'errors' property to display errors.

Instead of getting the errors object and then checking the property (`get('errors').get(property)`), just check the property (`get('errors.property')`).
