### PR TITLE
{{input}} helper with bindings are now recognized in child helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,17 +107,41 @@ Pass the `label` option to set the label text:
 {{input firstName label="Your Name"}}
 ```
 
+`label` could be pass as binding as well:
+
+```handlebars
+{{input firstName labelBinding="label"}}
+```
+
+where `label` could be a computed property defined in your controller.
+
 Pass the `placeholder` option to set a placeholder:
 
 ```handlebars
 {{input firstName placeholder="Enter your first name"}}
 ```
 
+`placeholder` could be pass as binding as well:
+
+```handlebars
+{{input firstName placeholderBinding="placeholder"}}
+```
+
+where `placeholder` could be a computed property defined in your controller. `prompt` for select can be pass as a binding as well. 
+
 Pass the `hint` option to set a hint:
 
 ```handlebars
 {{input firstName hint="Enter your first name"}}
 ```
+
+`hint` could be pass as binding as well:
+
+```handlebars
+{{input firstName hintBinding="hint"}}
+```
+
+where `hint` could be a computed property defined in your controller.
 
 Pass the `inputConfig` option to set the options used by the input field:
 

--- a/packages/ember-easyForm/lib/helpers/hintField.js
+++ b/packages/ember-easyForm/lib/helpers/hintField.js
@@ -1,5 +1,5 @@
 Ember.Handlebars.registerHelper('hintField', function(text, options) {
-  if (options.hash.text){
+  if (options.hash.text || options.hash.textBinding){
     return Ember.Handlebars.helpers.view.call(this, Ember.EasyForm.Hint, options);
   }
 });

--- a/packages/ember-easyForm/lib/views/hint.js
+++ b/packages/ember-easyForm/lib/views/hint.js
@@ -3,6 +3,6 @@ Ember.EasyForm.Hint = Ember.EasyForm.BaseView.extend({
   init: function() {
     this._super();
     this.classNames.push(this.getWrapperConfig('hintClass'));
-    this.set('template', Ember.Handlebars.compile(this.get('text')));
+    this.set('template', Ember.Handlebars.compile('{{view.text}}'));
   }
 });

--- a/packages/ember-easyForm/lib/views/input.js
+++ b/packages/ember-easyForm/lib/views/input.js
@@ -18,8 +18,9 @@ Ember.EasyForm.Input = Ember.EasyForm.BaseView.extend({
   didInsertElement: function() {
     this.set('labelField-'+this.elementId+'.for', this.get('inputField-'+this.elementId+'.elementId'));
   },
-  concatenatedProperties: ['inputOptions'],
+  concatenatedProperties: ['inputOptions', 'bindableInputOptions'],
   inputOptions: ['as', 'placeholder', 'inputConfig', 'collection', 'prompt', 'optionValuePath', 'optionLabelPath', 'selection', 'value'],
+  bindableInputOptions: ['placeholder', 'prompt'],
   fieldsForInput: function() {
     return this.labelField() +
            this.wrapControls(
@@ -29,18 +30,33 @@ Ember.EasyForm.Input = Ember.EasyForm.BaseView.extend({
            );
   },
   labelField: function() {
-    var options = this.label ? 'text="'+this.label+'"' : '';
+    var options, userOptions = this.inputOptions[this.inputOptions.length - 1];
+    
+    if (userOptions['labelBinding']) {
+      options = 'textBinding="'+userOptions['labelBinding']+'"';
+    } else {
+      options = this.label ? 'text="'+this.label+'"' : '';
+    }
+
     return '{{labelField '+this.property+' '+options+'}}';
   },
   inputField: function() {
-    var options = '', key, inputOptions = this.inputOptions;
-    for (var i = 0; i < inputOptions.length; i++) {
+    var options = '', key, value, keyBinding, inputOptions = this.inputOptions, userOptions = inputOptions[inputOptions.length - 1], bindableInputOptions = this.bindableInputOptions;
+    for (var i = 0; i < inputOptions.length-1; i++) {
       key = inputOptions[i];
       if (this[key]) {
         if (typeof(this[key]) === 'boolean') {
           this[key] = key;
         }
-        options = options.concat(''+key+'="'+this[inputOptions[i]]+'"');
+        value = this[inputOptions[i]];
+        
+        keyBinding = key + 'Binding';
+        if (userOptions[keyBinding] && bindableInputOptions.contains(key)) {
+          key = keyBinding;
+          value = userOptions[key];
+        }
+        
+        options = options.concat(''+key+'="'+value+'"');
       }
     }
 
@@ -53,7 +69,14 @@ Ember.EasyForm.Input = Ember.EasyForm.BaseView.extend({
     return '{{#if errors.' + this.property + '}}{{{errorField '+this.property+' '+options+'}}{{/if}}';
   },
   hintField: function() {
-    var options = this.hint ? 'text="'+this.hint+'"' : '';
+    var options, userOptions = this.inputOptions[this.inputOptions.length - 1];
+
+    if (userOptions['hintBinding']) {
+      options = 'textBinding="'+userOptions['hintBinding']+'"';
+    } else {
+      options = this.hint ? 'text="'+this.hint+'"' : '';
+    }
+
     return '{{hintField '+this.property+' '+options+'}}';
   },
   wrapControls: function(controls) {

--- a/packages/ember-easyForm/lib/views/label.js
+++ b/packages/ember-easyForm/lib/views/label.js
@@ -7,6 +7,6 @@ Ember.EasyForm.Label = Ember.EasyForm.BaseView.extend({
     this.set('template', this.renderText());
   },
   renderText: function() {
-    return Ember.Handlebars.compile(this.text || this.property.underscore().split('_').join(' ').capitalize());
+    return Ember.Handlebars.compile(this.text ? '{{view.text}}' : this.property.underscore().split('_').join(' ').capitalize());
   }
 });

--- a/packages/ember-easyForm/tests/helpers/input_test.js
+++ b/packages/ember-easyForm/tests/helpers/input_test.js
@@ -16,7 +16,12 @@ module('input helpers', {
       lastName: 'Cardarella',
       errors: Ember.Object.create()
     });
-    controller = Ember.ObjectController.create();
+    controller = Ember.ObjectController.create({
+      placeholder: 'A placeholder',
+      label: 'A label',
+      hint: 'A hint',
+      prompt: 'A prompt'
+    });
     controller.set('content', model);
   },
   teardown: function() {
@@ -107,7 +112,7 @@ test('block form for input', function() {
   equal(view.$().find('input').attr('type'), 'text');
 });
 
-test('sets input attributes propertly', function() {
+test('sets input attributes property', function() {
   view = Ember.View.create({
     template: templateFor('{{input receiveAt as="email" placeholder="Your email"}}'),
     controller: controller
@@ -200,4 +205,59 @@ test('sets errors in models created without the "errors" object', function(){
   });
   ok(view.$().find('div.fieldWithErrors').get(0));
   equal(view.$().find('span.error').text(), 'Some error!');
+});
+
+test('sets input attributes property as bindings', function() {
+  view = Ember.View.create({
+    template: templateFor('{{input firstName placeholderBinding="placeholder" labelBinding="label" hintBinding="hint"}}'),
+    controller: controller
+  });
+  append(view);
+
+  var input = view.$().find('input');
+  var label = view.$().find('label');
+  var hint = view.$().find('.hint');
+  equal(input.prop('placeholder'), controller.get('placeholder'));
+  equal(label.text(), controller.get('label'));
+  equal(hint.text(), controller.get('hint'));
+
+  Ember.run(function() {
+    controller.setProperties({
+      placeholder: 'Write your first name',
+      label: 'First name (not a last name)',
+      hint: 'Usually different than your last name'
+    });
+  });
+  
+  equal(input.prop('placeholder'), controller.get('placeholder'));
+  equal(label.text(), controller.get('label'));
+  equal(hint.text(), controller.get('hint'));
+});
+
+test('sets select prompt property as bindings', function() {
+  view = Ember.View.create({
+    template: templateFor('{{input firstName as="select" labelBinding="label" hintBinding="hint" promptBinding="prompt"}}'),
+    controller: controller
+  });
+  append(view);
+
+  var option = view.$().find('option');
+  var label = view.$().find('label');
+  var hint = view.$().find('.hint');
+
+  equal(option.text(), controller.get('prompt'));
+  equal(label.text(), controller.get('label'));
+  equal(hint.text(), controller.get('hint'));
+
+  Ember.run(function() {
+    controller.setProperties({
+      prompt: 'Select an option',
+      label: 'First name (not a last name)',
+      hint: 'Usually different than your last name'
+    });
+  });
+  
+  equal(option.text(), controller.get('prompt'));
+  equal(label.text(), controller.get('label'));
+  equal(hint.text(), controller.get('hint'));
 });


### PR DESCRIPTION
Passing bindings to helpers `{{inputField}}`, `{{hintField}}` and `{{labelField}}` work fine. However, it is does not work when they are passed to the `{{input}}` helper. This PR solve this issue. `prompt` and `placeholder` passed as bindings to `{{input}}` will be pass to `{{inputField}}` as binding. Idem for hint and label. For example `hint` passed as binding to `{{input}}` will be pass as `text`binding to `{{hintLabel}}`. Same pattern for label.

Tests have been added and they pass. 

README has been modified as well.

This reverts commit f5f2be5984eff3a22c67c9600fffcd76384d002a.
