### PR TITLE
Use property as default selection for select input

### DIFF
--- a/packages/ember-easyForm/lib/helpers/input-field.js
+++ b/packages/ember-easyForm/lib/helpers/input-field.js
@@ -53,6 +53,10 @@ Ember.Handlebars.registerHelper('input-field', function(property, options) {
     options.hash.selectionBinding = options.hash.selection;
     options.hash.valueBinding     = options.hash.value;
 
+    if (Ember.isNone(options.hash.selectionBinding) && Ember.isNone(options.hash.valueBinding)) {
+      options.hash.selectionBinding = property;
+    }
+
     return Ember.Handlebars.helpers.view.call(context, Ember.EasyForm.Select, options);
   } else {
     if (!options.hash.as) {

--- a/packages/ember-easyForm/tests/helpers/input-field_test.js
+++ b/packages/ember-easyForm/tests/helpers/input-field_test.js
@@ -329,6 +329,17 @@ test('generates a select input with correct selection', function() {
   ok(view.$().find('select option:selected').html().match(/United States/));
 });
 
+test('generates a select input with correct selection when no selection is specified', function() {
+  view = Ember.View.create({
+    template: templateFor('{{input-field country as="select" collection="optionsForCountry" optionValuePath="content.id" optionLabelPath="content.name"}}'),
+    container: container,
+    controller: controller
+  });
+
+  append(view);
+  ok(view.$().find('select option:selected').html().match(/United States/));
+});
+
 test('generates a select input correct value', function() {
   view = Ember.View.create({
     template: templateFor('{{input-field country as="select" collection="optionsForCountry" value="country.id" optionValuePath="content.id" optionLabelPath="content.name"}}'),


### PR DESCRIPTION
Use property as default selection binding for select input if neither selection nor value is provided.
