### PR TITLE
add input element class to wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Pass the `placeholder` option to set a placeholder:
 {{input firstName placeholderBinding="placeholder"}}
 ```
 
-where `placeholder` could be a computed property defined in your controller. `prompt` for select can be pass as a binding as well. 
+where `placeholder` could be a computed property defined in your controller. `prompt` for select can be pass as a binding as well.
 
 Pass the `hint` option to set a hint:
 
@@ -244,6 +244,7 @@ To customize how the form will be rendered you can use **wrappers**. A wrapper d
 * `formClass` - class used by the `form`
 * `fieldErrorClass` - class used by the field containing errors
 * `inputClass` - class used by the `div` containing all elements of the input (label, input, error and hint)
+* `inputElementClass` - class used by the input element (input, checkbox, textarea, select)
 * `errorClass` - class used by the error message
 * `hintClass` - class used by the hint message
 * `labelClass` - class used by the label
@@ -253,6 +254,7 @@ To customize how the form will be rendered you can use **wrappers**. A wrapper d
 ### Registering a wrapper
 To register a wrapper, use the method `Ember.EasyForm.Config.registerWrapper` passing the wrapper name and its options. You can define many wrappers, using each one when appropriate.
 
+#### Twitter Bootstrap
 ```javascript
 Ember.EasyForm.Config.registerWrapper('twitter-bootstrap', {
   formClass: 'form-horizontal',
@@ -263,6 +265,21 @@ Ember.EasyForm.Config.registerWrapper('twitter-bootstrap', {
   inputClass: 'control-group',
   wrapControls: true,
   controlsWrapperClass: 'controls'
+});
+```
+
+#### Twitter Bootstrap 3
+```javascript
+Ember.EasyForm.Config.registerWrapper('twitter-bootstrap-3', {
+  formClass: 'form-horizontal',
+  fieldErrorClass: 'error',
+  errorClass: 'help-inline',
+  hintClass: 'help-block',
+  labelClass: 'control-label col-lg-2',
+  inputClass: 'form-group',
+  inputElementClass: 'form-control',
+  wrapControls: true,
+  controlsWrapperClass: 'col-lg-10',
 });
 ```
 
@@ -285,6 +302,7 @@ The default wrapper contains the following values:
 * `formClass` - "" (empty)
 * `fieldErrorClass` - "fieldWithErrors"
 * `inputClass` - "input"
+* `inputElementClass` - "" (empty)
 * `errorClass` - "error"
 * `hintClass` - "hint"
 * `labelClass` - "" (empty)

--- a/packages/ember-easyForm/lib/config.js
+++ b/packages/ember-easyForm/lib/config.js
@@ -4,6 +4,7 @@ Ember.EasyForm.Config = Ember.Namespace.create({
       formClass: '',
       fieldErrorClass: 'fieldWithErrors',
       inputClass: 'input',
+      inputElementClass: '',
       errorClass: 'error',
       hintClass: 'hint',
       labelClass: '',

--- a/packages/ember-easyForm/lib/main.js
+++ b/packages/ember-easyForm/lib/main.js
@@ -1,5 +1,6 @@
 require('ember-easyForm/core');
 require('ember-easyForm/config');
+require('ember-easyForm/mixins');
 require('ember-easyForm/helpers');
 require('ember-easyForm/views');
 require('ember-easyForm/templates');

--- a/packages/ember-easyForm/lib/mixins.js
+++ b/packages/ember-easyForm/lib/mixins.js
@@ -1,0 +1,2 @@
+require('ember-easyForm/mixins/wrapperConfig');
+require('ember-easyForm/mixins/inputElementClass');

--- a/packages/ember-easyForm/lib/mixins/inputElementClass.js
+++ b/packages/ember-easyForm/lib/mixins/inputElementClass.js
@@ -1,0 +1,9 @@
+Ember.EasyForm.InputElementClassMixin = Ember.Mixin.create(Ember.EasyForm.WrapperConfigMixin, {
+  init: function() {
+    var cls = this.getWrapperConfig('inputElementClass');
+    this._super();
+    if (!Ember.isEmpty(cls)) {
+      this.classNames.push(cls);
+    }
+  },
+});

--- a/packages/ember-easyForm/lib/mixins/wrapperConfig.js
+++ b/packages/ember-easyForm/lib/mixins/wrapperConfig.js
@@ -1,0 +1,14 @@
+Ember.EasyForm.WrapperConfigMixin = Ember.Mixin.create({
+  getWrapperConfig: function(configName) {
+    var wrapper = Ember.EasyForm.Config.getWrapper(this.get('wrapper'));
+    return wrapper[configName];
+  },
+  wrapper: Ember.computed(function() {
+    var wrapperView = this.nearestWithProperty('wrapper');
+    if (wrapperView) {
+      return wrapperView.get('wrapper');
+    } else {
+      return 'default';
+    }
+  })
+});

--- a/packages/ember-easyForm/lib/views/base_view.js
+++ b/packages/ember-easyForm/lib/views/base_view.js
@@ -1,16 +1,4 @@
-Ember.EasyForm.BaseView = Ember.View.extend({
-  getWrapperConfig: function(configName) {
-    var wrapper = Ember.EasyForm.Config.getWrapper(this.get('wrapper'));
-    return wrapper[configName];
-  },
-  wrapper: Ember.computed(function() {
-    var wrapperView = this.nearestWithProperty('wrapper');
-    if (wrapperView) {
-      return wrapperView.get('wrapper');
-    } else {
-      return 'default';
-    }
-  }),
+Ember.EasyForm.BaseView = Ember.View.extend(Ember.EasyForm.WrapperConfigMixin, {
   formForModel: function(){
     var formForModelPath = this.get('templateData.keywords.formForModelPath');
 

--- a/packages/ember-easyForm/lib/views/checkbox.js
+++ b/packages/ember-easyForm/lib/views/checkbox.js
@@ -1,1 +1,1 @@
-Ember.EasyForm.Checkbox = Ember.Checkbox.extend();
+Ember.EasyForm.Checkbox = Ember.Checkbox.extend(Ember.EasyForm.InputElementClassMixin);

--- a/packages/ember-easyForm/lib/views/select.js
+++ b/packages/ember-easyForm/lib/views/select.js
@@ -1,1 +1,1 @@
-Ember.EasyForm.Select = Ember.Select.extend();
+Ember.EasyForm.Select = Ember.Select.extend(Ember.EasyForm.InputElementClassMixin);

--- a/packages/ember-easyForm/lib/views/textArea.js
+++ b/packages/ember-easyForm/lib/views/textArea.js
@@ -1,1 +1,1 @@
-Ember.EasyForm.TextArea = Ember.TextArea.extend();
+Ember.EasyForm.TextArea = Ember.TextArea.extend(Ember.EasyForm.InputElementClassMixin);

--- a/packages/ember-easyForm/lib/views/textField.js
+++ b/packages/ember-easyForm/lib/views/textField.js
@@ -1,1 +1,1 @@
-Ember.EasyForm.TextField = Ember.TextField.extend();
+Ember.EasyForm.TextField = Ember.TextField.extend(Ember.EasyForm.InputElementClassMixin);

--- a/packages/ember-easyForm/tests/helpers/input_test.js
+++ b/packages/ember-easyForm/tests/helpers/input_test.js
@@ -274,7 +274,7 @@ test('binds label to input field', function() {
 });
 
 test('uses the wrapper config', function() {
-  Ember.EasyForm.Config.registerWrapper('my_wrapper', {inputClass: 'my-input', errorClass: 'my-error', fieldErrorClass: 'my-fieldWithErrors'});
+  Ember.EasyForm.Config.registerWrapper('my_wrapper', {inputClass: 'my-input', inputElementClass: 'my-input-element', errorClass: 'my-error', fieldErrorClass: 'my-fieldWithErrors'});
   model['errors'] = ErrorsObject.create();
 
   Ember.run(function() {
@@ -290,8 +290,26 @@ test('uses the wrapper config', function() {
     view._childViews[0]._childViews[0].trigger('focusOut');
   });
   ok(view.$().find('div.my-input').get(0), 'inputClass not defined');
+  ok(view.$().find('input.my-input-element').get(0), 'inputElementClass not defined');
   ok(view.$().find('div.my-fieldWithErrors').get(0), 'fieldErrorClass not defined');
   ok(view.$().find('span.my-error').get(0), 'errorClass not defined');
+});
+
+test('uses the wrapper config on all input types', function() {
+  var template = '{{#form-for controller wrapper="my_wrapper"}}' +
+    '{{input firstName}}{{input lastName as="text"}}{{input title as="select"}}{{input alive as="checkbox"}}' +
+    '{{/form-for}}';
+  Ember.EasyForm.Config.registerWrapper('my_wrapper', {inputElementClass: 'my-input-element'});
+  view = Ember.View.create({
+    template: templateFor(template),
+    container: container,
+    controller: controller
+  });
+  append(view);
+  ok(view.$().find('input[type=text].my-input-element').get(0), 'inputElementClass not defined on text');
+  ok(view.$().find('input[type=checkbox].my-input-element').get(0), 'inputElementClass not defined on checkbox');
+  ok(view.$().find('select.my-input-element').get(0), 'inputElementClass not defined on select');
+  ok(view.$().find('textarea.my-input-element').get(0), 'inputElementClass not defined on textarea');
 });
 
 test('wraps controls when defined', function() {


### PR DESCRIPTION
Currently the wrapper is not compatible with bootstrap 3. Bootstrap 3 requires a class(form-control) on the input elements (input, checkbox, select, textarea).

This pull request adds inputElementClass(not sure if I am happy with this name) to the wrapper config. This class will be added to all of the input elements. 

All the easyForm inputs now require the wrapper config so I have moved that into a mixin.
