### PR TITLE
Disable ember-dev's clearing of Ember.TEMPLATES.

### DIFF
--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -28,6 +28,7 @@
     ENV['STUB_OBJECT_CREATE'] = !Object.create;
   }
 
+  EmberDev.afterEach = function(){};
   EmberDev.distros = {
     spade:   'ember-easyForm-spade.js',
     build:   'ember-easyForm.js',


### PR DESCRIPTION
`ember-dev` currently clears `Ember.TEMPLATES` after each test run. This will
be fixed in `ember-dev` with https://github.com/emberjs/ember-dev/pull/96.

This is a temporary fix until that PR is merged.
