### PR TITLE
Enabled inputOption "multiple" for select

### DIFF
--- a/packages/ember-easyForm/lib/views/input.js
+++ b/packages/ember-easyForm/lib/views/input.js
@@ -30,7 +30,7 @@ Ember.EasyForm.Input = Ember.EasyForm.BaseView.extend({
     this.set('label-field-'+this.elementId+'.for', this.get('input-field-'+this.elementId+'.elementId'));
   },
   concatenatedProperties: ['inputOptions', 'bindableInputOptions'],
-  inputOptions: ['as', 'collection', 'optionValuePath', 'optionLabelPath', 'selection', 'value'],
+  inputOptions: ['as', 'collection', 'optionValuePath', 'optionLabelPath', 'selection', 'value', 'multiple'],
   bindableInputOptions: ['placeholder', 'prompt'],
   controlsWrapperClass: function() {
     return this.getWrapperConfig('controlsWrapperClass');


### PR DESCRIPTION
input as="select" now supports multiple-inputOption, example: 
    {{input roles as='select'
        collection="modelRelations.roles"
        optionValuePath="content.id"
        optionLabelPath="content.name"
        multiple="true"}}
