### PR TITLE
Use nearestWithProperty for finding the wrapperView

### DIFF
--- a/packages/ember-easyForm/lib/views/base_view.js
+++ b/packages/ember-easyForm/lib/views/base_view.js
@@ -4,14 +4,11 @@ Ember.EasyForm.BaseView = Ember.View.extend({
     return wrapper[configName];
   },
   wrapper: Ember.computed(function() {
-    // Find the first parent with 'wrapper' defined.
-    var parentView = this.get('parentView');
-    while(parentView){
-      var config = parentView.get('wrapper');
-      if (config) return config;
-      parentView = parentView.get('parentView');
+    var wrapperView = this.nearestWithProperty('wrapper');
+    if (wrapperView) {
+      return wrapperView.get('wrapper');
+    } else {
+      return 'default';
     }
-
-    return 'default';
   })
 });


### PR DESCRIPTION
Just taking a look at easyForm, this popped out as duplicating a barely known method Ember provides.
