### PR TITLE
Extract the label humanising into a utility method

### DIFF
--- a/packages/ember-easyForm/lib/utilities.js
+++ b/packages/ember-easyForm/lib/utilities.js
@@ -1,3 +1,7 @@
+Ember.EasyForm.humanize = function(string) {
+  return string.underscore().split('_').join(' ').capitalize();
+};
+
 Ember.EasyForm.processOptions = function(property, options) {
   if (options) {
     options.hash.property = property;

--- a/packages/ember-easyForm/lib/views/label.js
+++ b/packages/ember-easyForm/lib/views/label.js
@@ -2,7 +2,7 @@ Ember.EasyForm.Label = Ember.EasyForm.BaseView.extend({
   tagName: 'label',
   attributeBindings: ['for'],
   labelText: function() {
-    return this.get('text') || this.get('property').underscore().split('_').join(' ').capitalize();
+    return this.get('text') || Ember.EasyForm.humanize(this.get('property'));
   }.property('text', 'property'),
   init: function() {
     this._super();

--- a/packages/ember-easyForm/tests/utilities_test.js
+++ b/packages/ember-easyForm/tests/utilities_test.js
@@ -1,3 +1,7 @@
 module('EasyForm utility methods', {
 
 });
+
+test('humanizes string', function() {
+  equal(Ember.EasyForm.humanize("firstName"), 'First name');
+});


### PR DESCRIPTION
In my project I like to have all words in a label capitalized, this extracts the humanizing out into a utility method.
With Ember 1.3 ish we can remove all this in favour of `Ember.String.humanize`
