### PR TITLE
Fix Travis failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 language: ruby
-script: "rake test\[all\]"
+before_script: sudo apt-get update && sudo apt-get install git
+script: rake test[all]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: 56b02fa1e623c6a22c793bd9d24b5be0bcd98f4b
+  revision: 55c3e48a8207f62ff971113858c70624f8c08d48
   branch: master
   specs:
     ember-dev (0.1)
@@ -27,16 +27,14 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (1.25.0)
+    aws-sdk (1.29.0)
       json (~> 1.4)
-      nokogiri (>= 1.4.4, < 1.6.0)
+      nokogiri (>= 1.4.4)
       uuidtools (~> 2.1)
     barber (0.4.2)
       ember-source
       execjs
       handlebars-source
-    celluloid (0.15.2)
-      timers (~> 1.1.0)
     colored (1.2)
     diff-lcs (1.2.5)
     ember-source (1.1.1)
@@ -49,16 +47,20 @@ GEM
       posix-spawn (~> 0.3.6)
     handlebars-source (1.0.12)
     json (1.8.1)
-    kicker (2.6.1)
-      listen
-    listen (2.2.0)
-      celluloid (>= 0.15.2)
+    kicker (3.0.0)
+      listen (~> 1.3.0)
+      notify (~> 0.5.2)
+    listen (1.3.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    mime-types (1.25)
-    nokogiri (1.5.10)
+      rb-kqueue (>= 0.2)
+    mime-types (1.25.1)
+    mini_portile (0.5.2)
+    nokogiri (1.6.0)
+      mini_portile (~> 0.5.0)
+    notify (0.5.2)
     posix-spawn (0.3.6)
-    puma (2.6.0)
+    puma (2.7.0)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)
     rake (10.1.0)
@@ -68,9 +70,10 @@ GEM
     rb-fsevent (0.9.3)
     rb-inotify (0.9.2)
       ffi (>= 0.5.0)
+    rb-kqueue (0.2.0)
+      ffi (>= 0.5.0)
     thor (0.18.1)
-    timers (1.1.0)
-    uglifier (2.3.1)
+    uglifier (2.3.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     uuidtools (2.1.4)

--- a/ember-dev.yml
+++ b/ember-dev.yml
@@ -1,5 +1,6 @@
 ---
 name: Ember EasyForm
+dasherized_name: ember-easyForm
 assetfile: 'Assetfile'
 testing_suites:
   default:


### PR DESCRIPTION
Fixes two issues with Travis:
- Travis has inadvertently reverted to Git 1.7.9.5. This has been
  reported, and the suggested work around was to update git prior to
  running our script.  See
  [here](https://github.com/travis-ci/travis-ci/issues/1710) for details.
- The prior `script` was apparently invalid YAML (the `\[` is interpreted
  as an escape sequence).
- The `ember-easyForm-spade.js` file was not being generated properly
  because `"Ember EasyForm".dasherize` == "ember-easyform", but we
  expect "ember-easyForm". This works fine with the default OS X setup
  since filenames are case-insensitive, but Travis runs on Linux which
  is case sensitive. This was fixed in ember-dev
  [here](https://github.com/emberjs/ember-dev/pull/105).
