### PR TITLE
Allow specifying a name property to {{input}}.

### DIFF
--- a/packages/ember-easyForm/lib/views/input.js
+++ b/packages/ember-easyForm/lib/views/input.js
@@ -30,7 +30,7 @@ Ember.EasyForm.Input = Ember.EasyForm.BaseView.extend({
     this.set('label-field-'+this.elementId+'.for', this.get('input-field-'+this.elementId+'.elementId'));
   },
   concatenatedProperties: ['inputOptions', 'bindableInputOptions'],
-  inputOptions: ['as', 'collection', 'optionValuePath', 'optionLabelPath', 'selection', 'value', 'multiple'],
+  inputOptions: ['as', 'collection', 'optionValuePath', 'optionLabelPath', 'selection', 'value', 'multiple', 'name'],
   bindableInputOptions: ['placeholder', 'prompt'],
   controlsWrapperClass: function() {
     return this.getWrapperConfig('controlsWrapperClass');

--- a/packages/ember-easyForm/tests/helpers/input_test.js
+++ b/packages/ember-easyForm/tests/helpers/input_test.js
@@ -365,3 +365,14 @@ test('sets select prompt property as bindings', function() {
   equal(view.$().find('label').text(), controller.get('label'));
   equal(view.$().find('.hint').text(), controller.get('hint'));
 });
+
+test('allows specifying the name property', function() {
+  view = Ember.View.create({
+    template: templateFor('{{input firstName name="first-name"}}'),
+    container: container,
+    controller: controller
+  });
+  append(view);
+
+  equal(view.$().find('input').prop('name'), "first-name");
+});


### PR DESCRIPTION
This is quite helpful when using the `ember-testing` helpers with jQuery selectors. Take the following example:

``` handlebars
{{#form-for controller}}
  {{input firstName name="first-name"}}
{{/form-for}}
```

``` javascript
visit('/');
fillIn('input[name="first-name"]', 'Robert');
```

Ultimately, we could infer this value based on the first argument (the field name) and add a default value all the time.
