### PR TITLE
Default an {{input}}'s name attribute to be the property name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,5 @@
 ## 1.0.0.beta.2
+
+  * Allow specifyin a name to the `{{input}}` helper. The provided name will be used
+    as the name attribute in the generated `<input>` tag.
+  * Use the property's name as the `<input>` tags `name` attribute.

--- a/packages/ember-easyForm/lib/views/input.js
+++ b/packages/ember-easyForm/lib/views/input.js
@@ -32,11 +32,18 @@ Ember.EasyForm.Input = Ember.EasyForm.BaseView.extend({
   concatenatedProperties: ['inputOptions', 'bindableInputOptions'],
   inputOptions: ['as', 'collection', 'optionValuePath', 'optionLabelPath', 'selection', 'value', 'multiple', 'name'],
   bindableInputOptions: ['placeholder', 'prompt'],
+  defaultOptions: {
+    name: function(){
+      if (this.property) {
+        return this.property;
+      }
+    }
+  },
   controlsWrapperClass: function() {
     return this.getWrapperConfig('controlsWrapperClass');
   }.property(),
   inputOptionsValues: function() {
-    var options = {}, i, key, keyBinding, inputOptions = this.inputOptions, bindableInputOptions = this.bindableInputOptions;
+    var options = {}, i, key, keyBinding, value, inputOptions = this.inputOptions, bindableInputOptions = this.bindableInputOptions, defaultOptions = this.defaultOptions;
     for (i = 0; i < inputOptions.length; i++) {
       key = inputOptions[i];
       if (this[key]) {
@@ -54,6 +61,16 @@ Ember.EasyForm.Input = Ember.EasyForm.BaseView.extend({
         options[keyBinding] = 'view.' + key;
       }
     }
+
+    for (key in defaultOptions) {
+      if (!defaultOptions.hasOwnProperty(key)) { continue; }
+      if (options[key]) { continue; }
+
+      if (value = defaultOptions[key].apply(this)) {
+        options[key] = value;
+      }
+    }
+
     return options;
   }.property(),
   focusOut: function() {

--- a/packages/ember-easyForm/tests/helpers/input_test.js
+++ b/packages/ember-easyForm/tests/helpers/input_test.js
@@ -370,15 +370,26 @@ test('sets select prompt property as bindings', function() {
   equal(view.$().find('.hint').text(), controller.get('hint'));
 });
 
-test('allows specifying the name property', function() {
+test('defaults the name property', function() {
   view = Ember.View.create({
-    template: templateFor('{{input firstName name="first-name"}}'),
+    template: templateFor('{{input firstName}}'),
     container: container,
     controller: controller
   });
   append(view);
 
-  equal(view.$().find('input').prop('name'), "first-name");
+  equal(view.$().find('input').prop('name'), "firstName");
+});
+
+test('allows specifying the name property', function() {
+  view = Ember.View.create({
+    template: templateFor('{{input firstName name="some-other-name"}}'),
+    container: container,
+    controller: controller
+  });
+  append(view);
+
+  equal(view.$().find('input').prop('name'), "some-other-name");
 });
 
 module('{{input}} without property argument', {


### PR DESCRIPTION
This is a follow-up to #81.
