### PR TITLE
Allow usage of Ember's {{input}} helper.

### DIFF
--- a/packages/ember-easyForm/lib/helpers/input.js
+++ b/packages/ember-easyForm/lib/helpers/input.js
@@ -1,4 +1,10 @@
+Ember.Handlebars.helpers['ember-input'] = Ember.Handlebars.helpers['input'];
+
 Ember.Handlebars.registerHelper('input', function(property, options) {
+  if (arguments.length === 1) {
+    return Ember.Handlebars.helpers['ember-input'].call(this, arguments[0]);
+  }
+
   options = Ember.EasyForm.processOptions(property, options);
   options.hash.isBlock = !!(options.fn);
   return Ember.Handlebars.helpers.view.call(this, Ember.EasyForm.Input, options);


### PR DESCRIPTION
Enable compatibility with the default Ember {{input}} helper.
- Move the original `{{input}}` helper to `{{ember-input}}` before replacing it.
- If EasyForm's `{{input}}` is used without specifying a propertyId use Ember's original `{{input}}` helper (now stored in `{{ember-input}}`).

Closes #83.
