### PR TITLE
Do not require models to be an Ember.Object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,6 @@
   * Allow specifyin a name to the `{{input}}` helper. The provided name will be used
     as the name attribute in the generated `<input>` tag.
   * Use the property's name as the `<input>` tags `name` attribute.
+  * Allow the model specified to `{{form-for}}` to be a regulare Javascript object (`{}`).
+  * Change `EasyForm.Button` and `EasyForm.Submit` to use the models `isValid` flag to
+    enable/disable the button.

--- a/packages/ember-easyForm/lib/helpers/input-field.js
+++ b/packages/ember-easyForm/lib/helpers/input-field.js
@@ -1,3 +1,6 @@
+var get = Ember.get,
+    set = Ember.set;
+
 Ember.Handlebars.registerHelper('input-field', function(property, options) {
   options = Ember.EasyForm.processOptions(property, options);
 
@@ -13,7 +16,7 @@ Ember.Handlebars.registerHelper('input-field', function(property, options) {
 
   var context = this,
     propertyType = function(property) {
-      var constructor = (context.get('content') || context).constructor;
+      var constructor = (get(context, 'content') || context).constructor;
 
       if (constructor.proto) {
         return Ember.meta(constructor.proto(), false).descs[property];
@@ -70,11 +73,11 @@ Ember.Handlebars.registerHelper('input-field', function(property, options) {
       } else if (property.match(/search/)) {
         options.hash.type = 'search';
       } else {
-        if (propertyType(property) === 'number' || typeof(context.get(property)) === 'number') {
+        if (propertyType(property) === 'number' || typeof(get(context,property)) === 'number') {
           options.hash.type = 'number';
-        } else if (propertyType(property) === 'date' || (!Ember.isNone(context.get(property)) && context.get(property).constructor === Date)) {
+        } else if (propertyType(property) === 'date' || (!Ember.isNone(get(context,property)) && get(context,property).constructor === Date)) {
           options.hash.type = 'date';
-        } else if (propertyType(property) === 'boolean' || (!Ember.isNone(context.get(property)) && context.get(property).constructor === Boolean)) {
+        } else if (propertyType(property) === 'boolean' || (!Ember.isNone(context.get(property)) && get(context,property).constructor === Boolean)) {
           options.hash.checkedBinding = property;
           return Ember.Handlebars.helpers.view.call(context, Ember.EasyForm.Checkbox, options);
         }

--- a/packages/ember-easyForm/lib/views/button.js
+++ b/packages/ember-easyForm/lib/views/button.js
@@ -4,8 +4,8 @@ Ember.EasyForm.Button = Ember.View.extend({
   attributeBindings: ['type', 'disabled'],
   type: 'submit',
   disabled: function() {
-    return this.get('context.isInvalid');
-  }.property('context.isInvalid'),
+    return !this.get('context.isValid');
+  }.property('context.isValid'),
   init: function() {
     this._super();
     this.set('context.text', this.value);

--- a/packages/ember-easyForm/lib/views/submit.js
+++ b/packages/ember-easyForm/lib/views/submit.js
@@ -3,8 +3,8 @@ Ember.EasyForm.Submit = Ember.View.extend({
   attributeBindings: ['type', 'value', 'disabled'],
   type: 'submit',
   disabled: function() {
-    return this.get('context.isInvalid');
-  }.property('context.isInvalid'),
+    return !this.get('context.isValid');
+  }.property('context.isValid'),
   init: function() {
     this._super();
     this.set('value', this.value);

--- a/packages/ember-easyForm/tests/helpers/error-field_test.js
+++ b/packages/ember-easyForm/tests/helpers/error-field_test.js
@@ -1,9 +1,10 @@
-var model, Model, view, container, controller, valid, ErrorsObject;
+var model, view, container, controller, valid, ErrorsObject,
+  get = Ember.get,
+  set = Ember.set;
 var templateFor = function(template) {
   return Ember.Handlebars.compile(template);
 };
 var original_lookup = Ember.lookup, lookup;
-Model = Ember.Object.extend();
 ErrorsObject = Ember.Object.extend({
   unknownProperty: function(property) {
     this.set(property, Ember.makeArray());
@@ -19,11 +20,11 @@ module('error-field helpers', {
       var name = fullName.split(':')[1];
       return Ember.TEMPLATES[name];
     };
-    model = Model.create({
+    model = {
       firstName: 'Brian',
       lastName: 'Cardarella',
       errors: ErrorsObject.create()
-    });
+    };
     controller = Ember.ObjectController.create();
     controller.set('content', model);
   },
@@ -51,15 +52,15 @@ test('error helper should bind to first error message in array', function() {
   append(view);
   equal(view.$().find('span.error').text(), '');
   Ember.run(function() {
-    model.get('errors.firstName').pushObject("can't be blank");
+    get(model, 'errors.firstName').pushObject("can't be blank");
   });
   equal(view.$().find('span.error').text(), "can't be blank");
   Ember.run(function() {
-    model.get('errors.firstName').unshiftObject('is invalid');
+    get(model, 'errors.firstName').unshiftObject('is invalid');
   });
   equal(view.$().find('span.error').text(), 'is invalid');
   Ember.run(function() {
-    model.get('errors.firstName').clear();
+    get(model, 'errors.firstName').clear();
   });
   equal(view.$().find('span.error').text(), '');
 });

--- a/packages/ember-easyForm/tests/helpers/form-for_test.js
+++ b/packages/ember-easyForm/tests/helpers/form-for_test.js
@@ -1,15 +1,16 @@
-var model, Model, view, container, controller, valid;
+var model, view, container, controller, valid,
+  get = Ember.get,
+  set = Ember.set;
+
 var templateFor = function(template) {
   return Ember.Handlebars.compile(template);
 };
 var original_lookup = Ember.lookup, lookup;
-Model = Ember.Object.extend({
-  validate: function() {
-    var promise = new Ember.Deferred();
-    promise.resolve();
-    return promise;
-  }
-});
+var validateFunction = function() {
+  var promise = new Ember.Deferred();
+  promise.resolve();
+  return promise;
+};
 
 module('the form-for helper', {
   setup: function() {
@@ -19,11 +20,12 @@ module('the form-for helper', {
       var name = fullName.split(':')[1];
       return Ember.TEMPLATES[name];
     };
-    model = Model.create({
+    model = {
       firstName: 'Brian',
       lastName: 'Cardarella',
-      errors: Ember.Object.create()
-    });
+      errors: Ember.Object.create(),
+      validate: validateFunction
+    };
     var Controller = Ember.ObjectController.extend({
       actions: {
         submit: function() {
@@ -74,7 +76,7 @@ test('uses the defined wrapper', function() {
 
 test('submitting with invalid model does not call submit action on controller', function() {
   Ember.run(function() {
-    model.set('isValid', false);
+    set(model, 'isValid', false);
   });
   view = Ember.View.create({
     template: templateFor('{{#form-for controller}}{{/form-for}}'),
@@ -90,7 +92,7 @@ test('submitting with invalid model does not call submit action on controller', 
 
 test('submitting with valid model calls submit action on controller', function() {
   Ember.run(function() {
-    model.set('isValid', true);
+    set(model, 'isValid', true);
   });
   view = Ember.View.create({
     template: templateFor('{{#form-for controller}}{{/form-for}}'),
@@ -129,7 +131,7 @@ test('submitting with valid controller calls submit action on controller', funct
 
 test('can override the action called by submit on the controller', function() {
   Ember.run(function() {
-    model.set('isValid', true);
+    set(model, 'isValid', true);
   });
   view = Ember.View.create({
     template: templateFor('{{#form-for controller action="bigSubmit"}}{{/form-for}}'),
@@ -162,7 +164,7 @@ test('submitting with model that does not have validate method', function() {
 
 test('submitting with ember-data model without validations can call submit action on controller', function() {
   Ember.run(function() {
-    model.set('isValid', false);
+    set(model, 'isValid', false);
     model.validate = undefined;
   });
   view = Ember.View.create({

--- a/packages/ember-easyForm/tests/helpers/hint-field_test.js
+++ b/packages/ember-easyForm/tests/helpers/hint-field_test.js
@@ -1,9 +1,11 @@
-var model, Model, view, container, controller, valid;
+var model, view, container, controller, valid,
+  get = Ember.get,
+  set = Ember.set;
+
 var templateFor = function(template) {
   return Ember.Handlebars.compile(template);
 };
 var original_lookup = Ember.lookup, lookup;
-Model = Ember.Object.extend();
 
 module('hint-field helpers', {
   setup: function() {
@@ -13,9 +15,7 @@ module('hint-field helpers', {
       var name = fullName.split(':')[1];
       return Ember.TEMPLATES[name];
     };
-    model = Model.create({
-      firstName: 'Brian',
-    });
+    model =  { firstName: 'Brian' };
     controller = Ember.ObjectController.create();
     controller.set('content', model);
   },

--- a/packages/ember-easyForm/tests/helpers/input-field_test.js
+++ b/packages/ember-easyForm/tests/helpers/input-field_test.js
@@ -1,9 +1,11 @@
-var model, Model, view, container, controller, valid, countries;
+var model, view, container, controller, valid, countries,
+  get = Ember.get,
+  set = Ember.set;
+
 var templateFor = function(template) {
   return Ember.Handlebars.compile(template);
 };
 var original_lookup = Ember.lookup, lookup;
-Model = Ember.Object.extend();
 
 module('input-field helpers', {
   setup: function() {
@@ -13,13 +15,13 @@ module('input-field helpers', {
       var name = fullName.split(':')[1];
       return Ember.TEMPLATES[name];
     };
-    countries = [Model.create({ id: 1, name: 'South Aftica' }), Model.create({ id: 2, name: 'United States' })];
+    countries = [{ id: 1, name: 'South Aftica' }, { id: 2, name: 'United States' }];
 
-    model = Model.create({
+    model = {
       firstName: 'Brian',
       lastName: 'Cardarella',
       country: countries[1]
-    });
+    };
 
     controller = Ember.ObjectController.create();
     controller.set('content', model);
@@ -182,15 +184,13 @@ test('auto sets input type to email if forced to email', function() {
 });
 
 test('auto sets input type to number if property meta attribute is a number', function() {
-   model.reopen({
-    metaForProperty: function(property) {
-      var obj = { 'type': 'number' };
-      if (property === 'age') {
-        return obj;
-      }
+  model['metaForProperty'] = function(property) {
+    var obj = { 'type': 'number' };
+    if (property === 'age') {
+      return obj;
     }
-  });
-  model.set('age', 30);
+  };
+  set(model,'age', 30);
   view = Ember.View.create({
     template: templateFor('{{input-field age}}'),
     container: container,
@@ -201,7 +201,7 @@ test('auto sets input type to number if property meta attribute is a number', fu
 });
 
 test('auto sets input type to number if property is a number', function() {
-  model.set('age', 30);
+  set(model,'age', 30);
   view = Ember.View.create({
     template: templateFor('{{input-field age}}'),
     container: container,
@@ -212,15 +212,13 @@ test('auto sets input type to number if property is a number', function() {
 });
 
 test('auto sets input type to date if property meta attribute is a date', function() {
-  model.reopen({
-    metaForProperty: function(property) {
-      var obj = { 'type': 'date' };
-      if (property === 'birthday') {
-        return obj;
-      }
+  model['metaForProperty'] = function(property) {
+    var obj = { 'type': 'date' };
+    if (property === 'birthday') {
+      return obj;
     }
-  });
-  model.set('birthday', new Date());
+  };
+  set(model,'birthday', new Date());
   view = Ember.View.create({
     template: templateFor('{{input-field birthday}}'),
     container: container,
@@ -231,7 +229,7 @@ test('auto sets input type to date if property meta attribute is a date', functi
 });
 
 test('auto sets input type to checkbox if forced to checkbox', function() {
-  model.set('alive', true);
+  set(model,'alive', true);
   view = Ember.View.create({
     template: templateFor('{{input-field alive as="checkbox"}}'),
     container: container,
@@ -243,15 +241,13 @@ test('auto sets input type to checkbox if forced to checkbox', function() {
 });
 
 test('auto sets input type to checkbox if property meta attribute is a boolean', function() {
-  model.reopen({
-    metaForProperty: function(property) {
-      var obj = { 'type': 'boolean' };
-      if (property === 'old') {
-        return obj;
-      }
+  model['metaForProperty'] = function(property) {
+    var obj = { 'type': 'boolean' };
+    if (property === 'old') {
+      return obj;
     }
-  });
-  model.set('old', false);
+  };
+  set(model,'old', false);
   view = Ember.View.create({
     template: templateFor('{{input-field old}}'),
     container: container,
@@ -262,7 +258,7 @@ test('auto sets input type to checkbox if property meta attribute is a boolean',
 });
 
 test('auto sets input type to number if property is a number', function() {
-  model.set('age', 30);
+  set(model,'age', 30);
   view = Ember.View.create({
     template: templateFor('{{input-field age}}'),
     container: container,

--- a/packages/ember-easyForm/tests/helpers/input_test.js
+++ b/packages/ember-easyForm/tests/helpers/input_test.js
@@ -1,4 +1,7 @@
-var model, Model, view, valid, container, controller, ErrorsObject, originalEmberWarn;
+var model, Model, view, valid, container, controller, ErrorsObject, originalEmberWarn,
+  set = Ember.set,
+  get = Ember.get;
+
 var templateFor = function(template) {
   return Ember.Handlebars.compile(template);
 };
@@ -17,10 +20,10 @@ function prepare(){
     var name = fullName.split(':')[1];
     return Ember.TEMPLATES[name];
   };
-  model = Ember.Object.create({
+  model = {
     firstName: 'Brian',
     lastName: 'Cardarella'
-  });
+  };
   controller = Ember.ObjectController.create({
     placeholder: 'A placeholder',
     label: 'A label',
@@ -78,12 +81,10 @@ test('does not render error tag when context does not have errors object', funct
 });
 
 test('renders error for invalid data', function() {
-  model.reopen({
-    errors: ErrorsObject.create()
-  });
+  model['errors'] = ErrorsObject.create();
 
   Ember.run(function() {
-    model.get('errors.firstName').pushObject("can't be blank");
+    get(model, 'errors.firstName').pushObject("can't be blank");
   });
 
   view = Ember.View.create({
@@ -109,7 +110,7 @@ test('renders error for invalid data', function() {
   equal(view.$().find('span.error').text(), "can't be blank");
 
   Ember.run(function() {
-    model.get('errors.firstName').clear();
+    get(model, 'errors.firstName').clear();
   });
   ok(!view.$().find('div.fieldWithErrors').get(0));
   ok(!view.$().find('span.error').get(0));
@@ -121,7 +122,7 @@ test('renders error for invalid data', function() {
   ok(!view.$().find('span.error').get(0));
 
   Ember.run(function() {
-    model.get('errors.firstName').pushObject("can't be blank");
+    get(model, 'errors.firstName').pushObject("can't be blank");
     view._childViews[0].trigger('input');
   });
   ok(!view.$().find('div.fieldWithErrors').get(0));
@@ -136,15 +137,13 @@ test('renders error for invalid data', function() {
 
 test('renders errors properly with dependent keys', function() {
   var passwordView, confirmationView;
-  model.reopen({
-    errors: ErrorsObject.create(),
-    _dependentValidationKeys: {
-      passwordConfirmation: ['password']
-    }
-  });
+  model['errors'] = ErrorsObject.create();
+  model['_dependentValidationKeys'] = {
+    passwordConfirmation: ['password']
+  };
 
   Ember.run(function() {
-    model.get('errors.passwordConfirmation').pushObject("does not match password");
+    get(model,'errors.passwordConfirmation').pushObject("does not match password");
   });
 
   view = Ember.View.create({
@@ -178,14 +177,14 @@ test('renders errors properly with dependent keys', function() {
   ok(confirmationView.$().find('span.error').get(0));
 
   Ember.run(function() {
-    model.get('errors.passwordConfirmation').clear();
+    get(model, 'errors.passwordConfirmation').clear();
     confirmationView.trigger('focusOut');
   });
   ok(!confirmationView.$().hasClass('fieldWithErrors'));
   ok(!confirmationView.$().find('span.error').get(0));
 
   Ember.run(function() {
-    model.get('errors.passwordConfirmation').pushObject("does not match password");
+    get(model, 'errors.passwordConfirmation').pushObject("does not match password");
     passwordView.trigger('input');
   });
   ok(confirmationView.$().hasClass('fieldWithErrors'));
@@ -260,12 +259,10 @@ test('binds label to input field', function() {
 
 test('uses the wrapper config', function() {
   Ember.EasyForm.Config.registerWrapper('my_wrapper', {inputClass: 'my-input', errorClass: 'my-error', fieldErrorClass: 'my-fieldWithErrors'});
-  model.reopen({
-    errors: ErrorsObject.create()
-  });
+  model['errors'] = ErrorsObject.create();
 
   Ember.run(function() {
-    model.get('errors.firstName').pushObject("can't be blank");
+    get(model,'errors.firstName').pushObject("can't be blank");
   });
   view = Ember.View.create({
     template: templateFor('{{#form-for controller wrapper="my_wrapper"}}{{input firstName}}{{/form-for}}'),
@@ -283,12 +280,10 @@ test('uses the wrapper config', function() {
 
 test('wraps controls when defined', function() {
   Ember.EasyForm.Config.registerWrapper('my_wrapper', {wrapControls: true, controlsWrapperClass: 'my-wrapper'});
-  model.reopen({
-    errors: ErrorsObject.create()
-  });
+  model['errors'] = ErrorsObject.create();
 
   Ember.run(function() {
-    model.get('errors.firstName').pushObject("can't be blank");
+    get(model, 'errors.firstName').pushObject("can't be blank");
   });
   view = Ember.View.create({
     template: templateFor('{{#form-for controller wrapper="my_wrapper"}}{{input firstName hint="my hint"}}{{/form-for}}'),

--- a/packages/ember-easyForm/tests/helpers/label-field_test.js
+++ b/packages/ember-easyForm/tests/helpers/label-field_test.js
@@ -1,9 +1,8 @@
-var model, Model, view, container, controller, valid;
+var model, view, container, controller, valid;
 var templateFor = function(template) {
   return Ember.Handlebars.compile(template);
 };
 var original_lookup = Ember.lookup, lookup;
-Model = Ember.Object.extend();
 
 module('label-field helpers', {
   setup: function() {
@@ -13,9 +12,9 @@ module('label-field helpers', {
       var name = fullName.split(':')[1];
       return Ember.TEMPLATES[name];
     };
-    model = Model.create({
+    model = {
       firstName: 'Brian',
-    });
+    };
     controller = Ember.ObjectController.create();
     controller.set('content', model);
   },

--- a/packages/ember-easyForm/tests/helpers/submit_test.js
+++ b/packages/ember-easyForm/tests/helpers/submit_test.js
@@ -1,4 +1,7 @@
-var model, view, container, controller, valid;
+var model, view, container, controller, valid,
+  set = Ember.set,
+  get = Ember.get;
+
 var templateFor = function(template) {
   return Ember.Handlebars.compile(template);
 };
@@ -12,13 +15,13 @@ module('submit helpers', {
       var name = fullName.split(':')[1];
       return Ember.TEMPLATES[name];
     };
-    model = Ember.Object.create({
+    model = {
       firstName: 'Brian',
       lastName: 'Cardarella',
       validate: function() {
         return valid;
       },
-    });
+    };
     var Controller = Ember.Controller.extend({
       actions: {
         submit: function() {
@@ -78,8 +81,7 @@ test('has custom value as button', function() {
 
 test('submit as button disabled state is bound to models valid state', function() {
   Ember.run(function() {
-    model.set('isValid', false);
-    model.reopen({isInvalid: Ember.computed.not('isValid')});
+    set(model,'isValid', false);
   });
   view = Ember.View.create({
     template: templateFor('{{submit as="button"}}'),
@@ -89,7 +91,7 @@ test('submit as button disabled state is bound to models valid state', function(
   append(view);
   equal(view.$().find('button').prop('disabled'), true);
   Ember.run(function() {
-    model.set('isValid', true);
+    set(model,'isValid', true);
   });
   equal(view.$().find('button').prop('disabled'), false);
 });
@@ -106,8 +108,8 @@ test('custom value', function() {
 
 test('submit button disabled state is bound to models valid state', function() {
   Ember.run(function() {
-    model.set('isValid', false);
-    model.reopen({isInvalid: Ember.computed.not('isValid')});
+    set(model,'isValid', false);
+    model = Ember.Object.create(model);
   });
   view = Ember.View.create({
     template: templateFor('{{submit}}'),
@@ -117,7 +119,7 @@ test('submit button disabled state is bound to models valid state', function() {
   append(view);
   equal(view.$().find('input').prop('disabled'), true);
   Ember.run(function() {
-    model.set('isValid', true);
+    set(model,'isValid', true);
   });
   equal(view.$().find('input').prop('disabled'), false);
 });


### PR DESCRIPTION
- Changes tests to use POJO's instead of an Ember.Object.
- Changed Ember.EasyForm.Button and Ember.EasyForm.Submit to use
  `isValid` on the model instead of `isInvalid`. This makes it easier
  to implement custom validations (without `ember-validations`) since
  only one value is needed for checking validity.

Resolves #87.
