### PR TITLE
Use the form's model as the scope for {{input}}.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@
   * Allow the model specified to `{{form-for}}` to be a regulare Javascript object (`{}`).
   * Change `EasyForm.Button` and `EasyForm.Submit` to use the models `isValid` flag to
     enable/disable the button.
+  * Change `EasyForm.Button` and `EasyForm.Submit` to inherit from `EasyForm.BaseView`.
+  * Use the model passed to the `{{form-for}}` helper as the scope for the properties
+    provided to the `{{input}}` helper. This allows using something other than the
+    controllers `model`/`content` as a forms model.

--- a/packages/ember-easyForm/lib/helpers/form-for.js
+++ b/packages/ember-easyForm/lib/helpers/form-for.js
@@ -1,4 +1,4 @@
 Ember.Handlebars.registerHelper('form-for', function(object, options) {
-  options.hash.contentBinding = object;
+  options.data.keywords.formForModelPath = object;
   return Ember.Handlebars.helpers.view.call(this, Ember.EasyForm.Form, options);
 });

--- a/packages/ember-easyForm/lib/helpers/input-field.js
+++ b/packages/ember-easyForm/lib/helpers/input-field.js
@@ -12,7 +12,28 @@ Ember.Handlebars.registerHelper('input-field', function(property, options) {
     options.hash.inputOptions = Ember.Handlebars.get(this, options.hash.inputOptionsBinding, options);
   }
 
+  var modelPath = Ember.Handlebars.get(this, 'formForModelPath', options);
+  options.hash.modelPath = modelPath;
+
   property = options.hash.property;
+
+  var modelPropertyPath = function(property) {
+    if(!property) { return null; }
+
+    var startsWithKeyword = !!options.data.keywords[property.split('.')[0]];
+
+    if (startsWithKeyword) {
+      return property;
+    }
+
+    if (modelPath) {
+      return modelPath + '.' + property;
+    } else {
+      return property;
+    }
+  };
+
+  options.hash.valueBinding = modelPropertyPath(property);
 
   var context = this,
     propertyType = function(property) {
@@ -25,7 +46,6 @@ Ember.Handlebars.registerHelper('input-field', function(property, options) {
       }
     };
 
-  options.hash.valueBinding = property;
   options.hash.viewName = 'input-field-'+options.data.view.elementId;
 
   if (options.hash.inputOptions) {
@@ -43,18 +63,18 @@ Ember.Handlebars.registerHelper('input-field', function(property, options) {
   } else if (options.hash.as === 'select') {
     delete(options.hash.valueBinding);
 
-    options.hash.contentBinding   = options.hash.collection;
-    options.hash.selectionBinding = options.hash.selection;
-    options.hash.valueBinding     = options.hash.value;
+    options.hash.contentBinding   = modelPropertyPath(options.hash.collection);
+    options.hash.selectionBinding = modelPropertyPath(options.hash.selection);
+    options.hash.valueBinding     = modelPropertyPath(options.hash.value);
 
     if (Ember.isNone(options.hash.selectionBinding) && Ember.isNone(options.hash.valueBinding)) {
-      options.hash.selectionBinding = property;
+      options.hash.selectionBinding = modelPropertyPath(property);
     }
 
     return Ember.Handlebars.helpers.view.call(context, Ember.EasyForm.Select, options);
   } else if (options.hash.as === 'checkbox') {
     if (Ember.isNone(options.hash.checkedBinding)) {
-      options.hash.checkedBinding = property;
+      options.hash.checkedBinding = modelPropertyPath(property);
     }
 
     return Ember.Handlebars.helpers.view.call(context, Ember.EasyForm.Checkbox, options);

--- a/packages/ember-easyForm/lib/views/base_view.js
+++ b/packages/ember-easyForm/lib/views/base_view.js
@@ -10,5 +10,14 @@ Ember.EasyForm.BaseView = Ember.View.extend({
     } else {
       return 'default';
     }
-  })
+  }),
+  formForModel: function(){
+    var formForModelPath = this.get('templateData.keywords.formForModelPath');
+
+    if (formForModelPath) {
+      return this.get('context.' + formForModelPath);
+    } else {
+      return this.get('context');
+    }
+  }.property(),
 });

--- a/packages/ember-easyForm/lib/views/button.js
+++ b/packages/ember-easyForm/lib/views/button.js
@@ -1,13 +1,13 @@
-Ember.EasyForm.Button = Ember.View.extend({
+Ember.EasyForm.Button = Ember.EasyForm.BaseView.extend({
   tagName: 'button',
   template: Ember.Handlebars.compile('{{text}}'),
   attributeBindings: ['type', 'disabled'],
   type: 'submit',
   disabled: function() {
-    return !this.get('context.isValid');
-  }.property('context.isValid'),
+    return !this.get('formForModel.isValid');
+  }.property('formForModel.isValid'),
   init: function() {
     this._super();
-    this.set('context.text', this.value);
+    this.set('formForModel.text', this.value);
   }
 });

--- a/packages/ember-easyForm/lib/views/error.js
+++ b/packages/ember-easyForm/lib/views/error.js
@@ -3,7 +3,7 @@ Ember.EasyForm.Error = Ember.EasyForm.BaseView.extend({
   init: function() {
     this._super();
     this.classNames.push(this.getWrapperConfig('errorClass'));
-    Ember.Binding.from('context.errors.' + this.property).to('errors').connect(this);
+    Ember.Binding.from('formForModel.errors.' + this.property).to('errors').connect(this);
   },
   templateName: 'easyForm/error'
 });

--- a/packages/ember-easyForm/lib/views/form.js
+++ b/packages/ember-easyForm/lib/views/form.js
@@ -9,22 +9,23 @@ Ember.EasyForm.Form = Ember.EasyForm.BaseView.extend({
     this.action = this.action || 'submit';
   },
   submit: function(event) {
-    var _this = this, promise;
+    var _this = this,
+        promise;
 
     if (event) {
       event.preventDefault();
     }
 
-    if (Ember.isNone(this.get('context.validate'))) {
+    if (Ember.isNone(this.get('formForModel.validate'))) {
       this.get('controller').send(this.action);
     } else {
-      if (!Ember.isNone(this.get('context').validate)) {
-        promise = this.get('context').validate();
+      if (!Ember.isNone(this.get('formForModel').validate)) {
+        promise = this.get('formForModel').validate();
       } else {
-        promise = this.get('context.content').validate();
+        promise = this.get('formForModel.content').validate();
       }
       promise.then(function() {
-        if (_this.get('context.isValid')) {
+        if (_this.get('formForModel.isValid')) {
           _this.get('controller').send(_this.action);
         }
       });

--- a/packages/ember-easyForm/lib/views/input.js
+++ b/packages/ember-easyForm/lib/views/input.js
@@ -3,7 +3,7 @@ Ember.EasyForm.Input = Ember.EasyForm.BaseView.extend({
     this._super();
     this.classNameBindings.push('showError:' + this.getWrapperConfig('fieldErrorClass'));
     this.classNames.push(this.getWrapperConfig('inputClass'));
-    Ember.defineProperty(this, 'showError', Ember.computed.and('canShowValidationError', 'context.errors.' + this.property + '.firstObject'));
+    Ember.defineProperty(this, 'showError', Ember.computed.and('canShowValidationError', 'formForModel.errors.' + this.property + '.firstObject'));
     if (!this.isBlock) {
       if (this.getWrapperConfig('wrapControls')) {
         this.set('templateName', 'easyForm/wrapped_input');
@@ -13,7 +13,7 @@ Ember.EasyForm.Input = Ember.EasyForm.BaseView.extend({
     }
   },
   setupValidationDependencies: function() {
-    var keys = this.get('context._dependentValidationKeys'), key;
+    var keys = this.get('formForModel._dependentValidationKeys'), key;
     if (keys) {
       for(key in keys) {
         if (keys[key].contains(this.property)) {
@@ -79,7 +79,7 @@ Ember.EasyForm.Input = Ember.EasyForm.BaseView.extend({
   },
   showValidationError: function() {
     if (this.get('hasFocusedOut')) {
-      if (Ember.isEmpty(this.get('context.errors.' + this.property))) {
+      if (Ember.isEmpty(this.get('formForModel.errors.' + this.property))) {
         this.set('canShowValidationError', false);
       } else {
         this.set('canShowValidationError', true);

--- a/packages/ember-easyForm/lib/views/submit.js
+++ b/packages/ember-easyForm/lib/views/submit.js
@@ -1,10 +1,10 @@
-Ember.EasyForm.Submit = Ember.View.extend({
+Ember.EasyForm.Submit = Ember.EasyForm.BaseView.extend({
   tagName: 'input',
   attributeBindings: ['type', 'value', 'disabled'],
   type: 'submit',
   disabled: function() {
-    return !this.get('context.isValid');
-  }.property('context.isValid'),
+    return !this.get('formForModel.isValid');
+  }.property('formForModel.isValid'),
   init: function() {
     this._super();
     this.set('value', this.value);

--- a/packages/ember-easyForm/tests/helpers/form-for_test.js
+++ b/packages/ember-easyForm/tests/helpers/form-for_test.js
@@ -57,7 +57,7 @@ var append = function(view) {
 
 test('renders a form element', function() {
   view = Ember.View.create({
-    template: templateFor('{{#form-for controller}}{{/form-for}}'),
+    template: templateFor('{{#form-for model}}{{/form-for}}'),
     controller: controller
   });
   append(view);
@@ -67,7 +67,7 @@ test('renders a form element', function() {
 test('uses the defined wrapper', function() {
   Ember.EasyForm.Config.registerWrapper('my_wrapper', {formClass: 'my-form-class'});
   view = Ember.View.create({
-    template: templateFor('{{#form-for controller wrapper="my_wrapper"}}{{/form-for}}'),
+    template: templateFor('{{#form-for model wrapper="my_wrapper"}}{{/form-for}}'),
     controller: controller
   });
   append(view);
@@ -79,7 +79,7 @@ test('submitting with invalid model does not call submit action on controller', 
     set(model, 'isValid', false);
   });
   view = Ember.View.create({
-    template: templateFor('{{#form-for controller}}{{/form-for}}'),
+    template: templateFor('{{#form-for model}}{{/form-for}}'),
     container: container,
     controller: controller
   });
@@ -95,7 +95,7 @@ test('submitting with valid model calls submit action on controller', function()
     set(model, 'isValid', true);
   });
   view = Ember.View.create({
-    template: templateFor('{{#form-for controller}}{{/form-for}}'),
+    template: templateFor('{{#form-for model}}{{/form-for}}'),
     container: container,
     controller: controller
   });
@@ -118,7 +118,7 @@ test('submitting with valid controller calls submit action on controller', funct
     controller.set('isValid', true);
   });
   view = Ember.View.create({
-    template: templateFor('{{#form-for controller}}{{/form-for}}'),
+    template: templateFor('{{#form-for model}}{{/form-for}}'),
     container: container,
     controller: controller
   });
@@ -134,7 +134,7 @@ test('can override the action called by submit on the controller', function() {
     set(model, 'isValid', true);
   });
   view = Ember.View.create({
-    template: templateFor('{{#form-for controller action="bigSubmit"}}{{/form-for}}'),
+    template: templateFor('{{#form-for model action="bigSubmit"}}{{/form-for}}'),
     container: container,
     controller: controller
   });
@@ -151,7 +151,7 @@ test('submitting with model that does not have validate method', function() {
     controller.set('content', model);
   });
   view = Ember.View.create({
-    template: templateFor('{{#form-for controller}}{{/form-for}}'),
+    template: templateFor('{{#form-for model}}{{/form-for}}'),
     container: container,
     controller: controller
   });
@@ -168,7 +168,7 @@ test('submitting with ember-data model without validations can call submit actio
     model.validate = undefined;
   });
   view = Ember.View.create({
-    template: templateFor('{{#form-for controller}}{{/form-for}}'),
+    template: templateFor('{{#form-for model}}{{/form-for}}'),
     container: container,
     controller: controller
   });
@@ -179,20 +179,45 @@ test('submitting with ember-data model without validations can call submit actio
   equal(controller.get('count'), 1);
 });
 
-test('integration w input: ', function() {
+test('uses the specified model as the basis for {{input}} property lookup', function() {
   view = Ember.View.create({
-    template: templateFor('{{#form-for theModel}}{{input foo id="easy-input"}} <div id="asl">{{foo}}</div> {{input id="ember-input" value=foo}}{{/form-for}}'),
+    template: templateFor('{{#form-for theModel}}{{input foo name="easy-input"}} <div id="asl">{{foo}}</div> {{input id="ember-input" value=foo}}{{/form-for}}'),
     container: container,
     controller: Ember.Controller.create({
-      theModel: Ember.Object.create({
-        foo: "LOL"
-      }),
+      theModel: { foo: "LOL" },
       foo: "BORING"
     })
   });
   append(view);
 
-  equal(view.$('#easy-input').val(), "LOL", "easy-input uses form-for's model as its context for looking up its property");
+  equal(view.$('input[name="easy-input"]').val(), "LOL", "easy-input uses form-for's model as its context for looking up its property");
   equal(view.$('#ember-input').val(), "BORING", "vanilla ember inputs are unaffected by form-for");
   equal(view.$('#asl').text(), "BORING", "form-for doesn't change context for plain ol bindings");
+});
+
+test('uses the specified models validation object', function() {
+  model = {
+    theModel: {
+      validate: validateFunction
+    },
+    count: 0
+  };
+  controller.set('content', model);
+  view = Ember.View.create({
+    template: templateFor('{{#form-for theModel}}{{input foo}}{{/form-for}}'),
+    container: container,
+    controller: controller
+  });
+  append(view);
+
+  Ember.run(function() {
+    view._childViews[0].trigger('submit');
+  });
+  equal(controller.get('count'), 0);
+
+  set(model, 'theModel.isValid', true);
+  Ember.run(function() {
+    view._childViews[0].trigger('submit');
+  });
+  equal(controller.get('count'), 1);
 });

--- a/packages/ember-easyForm/tests/helpers/input_test.js
+++ b/packages/ember-easyForm/tests/helpers/input_test.js
@@ -265,7 +265,7 @@ test('uses the wrapper config', function() {
     get(model,'errors.firstName').pushObject("can't be blank");
   });
   view = Ember.View.create({
-    template: templateFor('{{#form-for controller wrapper="my_wrapper"}}{{input firstName}}{{/form-for}}'),
+    template: templateFor('{{#form-for model wrapper="my_wrapper"}}{{input firstName}}{{/form-for}}'),
     container: container,
     controller: controller
   });
@@ -286,7 +286,7 @@ test('wraps controls when defined', function() {
     get(model, 'errors.firstName').pushObject("can't be blank");
   });
   view = Ember.View.create({
-    template: templateFor('{{#form-for controller wrapper="my_wrapper"}}{{input firstName hint="my hint"}}{{/form-for}}'),
+    template: templateFor('{{#form-for model wrapper="my_wrapper"}}{{input firstName hint="my hint"}}{{/form-for}}'),
     container: container,
     controller: controller
   });
@@ -304,7 +304,7 @@ test('wraps controls when defined', function() {
 test('does not wrap controls when not defined', function() {
   Ember.EasyForm.Config.registerWrapper('my_wrapper', {wrapControls: false, controlsWrapperClass: 'my-wrapper'});
   view = Ember.View.create({
-    template: templateFor('{{#form-for controller wrapper="my_wrapper"}}{{input firstName hint="my hint"}}{{/form-for}}'),
+    template: templateFor('{{#form-for model wrapper="my_wrapper"}}{{input firstName hint="my hint"}}{{/form-for}}'),
     container: container,
     controller: controller
   });
@@ -385,6 +385,48 @@ test('allows specifying the name property', function() {
   append(view);
 
   equal(view.$().find('input').prop('name'), "some-other-name");
+});
+
+test('scopes property lookup to model declared in form-for', function(){
+  controller.set('someOtherModel', Ember.Object.create({firstName: 'Robert'}));
+
+  view = Ember.View.create({
+    template: templateFor('{{#form-for someOtherModel}}{{input firstName}}{{/form-for}}'),
+    container: container,
+    controller: controller
+  });
+  append(view);
+
+  equal(view.$().find('input').val(), "Robert");
+});
+
+test('can specify a property outside of the model if a keyword is used as a prefix', function(){
+  controller.set('someOtherModel', Ember.Object.create({firstName: 'Robert'}));
+
+  view = Ember.View.create({
+    template: templateFor('{{#form-for someOtherModel}}{{input controller.firstName}}{{/form-for}}'),
+    container: container,
+    controller: controller
+  });
+  append(view);
+
+  equal(view.$().find('input').val(), "Brian");
+});
+
+test('select collection can use controller scope if prefix', function() {
+  controller.set('someOtherModel', Ember.Object.create({ city: 'Ocala' }));
+
+  controller.set('cities', Ember.A("Boston Ocala Portland".w()));
+
+  view = Ember.View.create({
+    template: templateFor('{{#form-for someOtherModel}}{{input city as="select" collection="controller.cities"}}{{/form-for}}'),
+    container: container,
+    controller: controller
+  });
+  append(view);
+
+  equal(view.$('option').text(), "BostonOcalaPortland");
+  equal(view.$('option:selected').text(), "Ocala");
 });
 
 module('{{input}} without property argument', {


### PR DESCRIPTION
- Adds a `formForModelPath` keyword to the views scope in the
  `{{form-for}}` helper.
- Uses that keyword as the basis for property lookups.
- Does NOT change the actual context of the block passed to
  `{{form-for}}`.
- Adds an additional helper to `Ember.EasyForm.BaseView` to lookup the
  forms model (based on the path provided when calling `{{form-for}}`).
- Ensure that a forms validation is performed against the model
  object specified.
- Change tests to use `{{form-for content}}` instead of `{{form-for
  controller}}` (`controller` is not a valid keyword under the view
  `context`)
- Allows binding to a property outside of the current forms model scope
  if the property is prefixed by a keyword (examples: `view` or `controller`).
- Changes `Ember.EasyForm.Button` and `Ember.EasyForm.Submit` to inherit from
  `Ember.EasyForm.BaseView`. Previously was using `Ember.View`.

Resolves #85.
Closes #86.
