### PR TITLE
Fixes the error thrown when using `{{input}}` as a block without label.

### DIFF
--- a/packages/ember-easyForm/lib/views/input.js
+++ b/packages/ember-easyForm/lib/views/input.js
@@ -27,7 +27,10 @@ Ember.EasyForm.Input = Ember.EasyForm.BaseView.extend({
   tagName: 'div',
   classNames: ['string'],
   didInsertElement: function() {
-    this.set('label-field-'+this.elementId+'.for', this.get('input-field-'+this.elementId+'.elementId'));
+    var name = 'label-field-'+this.elementId+'.for',
+        label = Ember.$('#' + name);
+    if (this.isBlock && !label[0]) { return; }
+    this.set(name, this.get('input-field-'+this.elementId+'.elementId'));
   },
   concatenatedProperties: ['inputOptions', 'bindableInputOptions'],
   inputOptions: ['as', 'collection', 'optionValuePath', 'optionLabelPath', 'selection', 'value', 'multiple', 'name'],

--- a/packages/ember-easyForm/tests/helpers/input_test.js
+++ b/packages/ember-easyForm/tests/helpers/input_test.js
@@ -233,6 +233,17 @@ test('block form for input', function() {
   equal(view.$().find('input').attr('type'), 'text');
 });
 
+test('block form for input without label', function() {
+  view = Ember.View.create({
+    template: templateFor('{{#input firstName}}{{input-field firstName}}{{/input}}'),
+    container: container,
+    controller: controller
+  });
+  append(view);
+  equal(view.$().find('input').val(), 'Brian');
+  equal(view.$().find('input').attr('type'), 'text');
+});
+
 test('sets input attributes property', function() {
   view = Ember.View.create({
     template: templateFor('{{input receiveAt as="email" placeholder="Your email"}}'),


### PR DESCRIPTION
This is helpful for mobile pages, when you use placeholder text instead
of labels.

``` html
{{#input username}}
  {{input-field username}}
  {{error-field username}}
{{/input}}
```
