### PR TITLE
Displays all errors when submitting an invalid form.

### DIFF
--- a/packages/ember-easyForm/lib/views/form.js
+++ b/packages/ember-easyForm/lib/views/form.js
@@ -27,8 +27,31 @@ Ember.EasyForm.Form = Ember.EasyForm.BaseView.extend({
       promise.then(function() {
         if (_this.get('formForModel.isValid')) {
           _this.get('controller').send(_this.action);
+        } else {
+          showAllErrors(_this);
         }
+      }, function() {
+        showAllErrors(_this);
       });
     }
   }
 });
+
+
+function showAllErrors(view) {
+  if (view.isDestroyed) {
+    return;
+  }
+
+  if (view.showValidationError && view.focusOut) {
+    view.focusOut();
+  }
+
+  var views = Ember.get(view, '_childViews');
+  if (views) {
+    views.forEach(function(view) {
+      showAllErrors(view);
+    });
+  }
+}
+

--- a/packages/ember-easyForm/tests/helpers/form-for_test.js
+++ b/packages/ember-easyForm/tests/helpers/form-for_test.js
@@ -90,6 +90,23 @@ test('submitting with invalid model does not call submit action on controller', 
   equal(controller.get('count'), 0);
 });
 
+test('submitting with invalid model displays all errors', function() {
+  Ember.run(function() {
+    set(model, 'isValid', false);
+    set(model, 'errors.firstName', ['is invalid']);
+  });
+  view = Ember.View.create({
+    template: templateFor('{{#form-for model}}{{input firstName}}{{/form-for}}'),
+    container: container,
+    controller: controller
+  });
+  append(view);
+  Ember.run(function() {
+    view._childViews[0].trigger('submit');
+  });
+  equal(view.$().find('span.error').text(), 'is invalid');
+});
+
 test('submitting with valid model calls submit action on controller', function() {
   Ember.run(function() {
     set(model, 'isValid', true);


### PR DESCRIPTION
The default behavior of the easyForm is to disable the submit button until the model is valid. In my application I'm keeping the submit button enabled, and when the user submits the form, all errors are displayed.

With this PR, all errors are going to be displayed when the form is submitted.

It does not change the default behavior, it still keeps the submit button disabled until the model is valid, it will only have any effect when someone keeps the submit always enabled. For example:

``` handlebars
{{#form-for model}}
  {{submit disabled=false}}
{{/form-for}}
```
