### PR TITLE
Publish builds to S3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: ruby
 before_script: sudo apt-get update && sudo apt-get install git
 script: bundle exec rake test[all]
+after_success: bundle exec rake publish_build BUILD_TYPE=release
+env:
+  global:
+  - S3_BUCKET_NAME=builds.dockyard.com
+  - S3_FILE_PREFIX=ember-easyForm

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: 55c3e48a8207f62ff971113858c70624f8c08d48
+  revision: d99ab73e754317fde34b82139edd8c433a845aad
   branch: master
   specs:
     ember-dev (0.1)
@@ -27,7 +27,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (1.29.0)
+    aws-sdk (1.32.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
       uuidtools (~> 2.1)
@@ -56,24 +56,24 @@ GEM
       rb-kqueue (>= 0.2)
     mime-types (1.25.1)
     mini_portile (0.5.2)
-    nokogiri (1.6.0)
+    nokogiri (1.6.1)
       mini_portile (~> 0.5.0)
     notify (0.5.2)
-    posix-spawn (0.3.6)
-    puma (2.7.0)
+    posix-spawn (0.3.8)
+    puma (2.7.1)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)
-    rake (10.1.0)
+    rake (10.1.1)
     rake-pipeline-web-filters (0.7.0)
       rack
       rake-pipeline (~> 0.6)
-    rb-fsevent (0.9.3)
-    rb-inotify (0.9.2)
+    rb-fsevent (0.9.4)
+    rb-inotify (0.9.3)
       ffi (>= 0.5.0)
     rb-kqueue (0.2.0)
       ffi (>= 0.5.0)
     thor (0.18.1)
-    uglifier (2.3.2)
+    uglifier (2.4.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     uuidtools (2.1.4)

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,23 @@
 require 'bundler/setup'
 require 'ember-dev/tasks'
 
+task :publish_build => [:dist, 'ember:generate_static_test_site'] do
+  root_dir = Pathname.new(__FILE__).dirname
+  dist_dir = root_dir.join('dist')
+
+  files = %w{ember-easyForm.js ember-easyForm-spade.js
+             ember-easyForm-tests.js ember-easyForm-tests.html}
+
+  EmberDev::Publish.to_s3({
+    :access_key_id => ENV['S3_ACCESS_KEY_ID'],
+    :secret_access_key => ENV['S3_SECRET_ACCESS_KEY'],
+    :bucket_name => ENV['S3_BUCKET_NAME'],
+    :subdirectory => ENV['S3_FILE_PREFIX'],
+
+    :files => files.map { |f| dist_dir.join(f) }
+  })
+end
+
 task :clean => 'ember:clean'
 task :dist => 'ember:dist'
 task :test, [:suite] => 'ember:test'


### PR DESCRIPTION
This will publish builds to S3 to the following URL's:

```
<S3_FILE_PREFIX>/ember-easyForm.js
<S3_FILE_PREFIX>/ember-easyForm.prod.js
<S3_FILE_PREFIX>/ember-easyForm.min.js
<S3_FILE_PREFIX>/daily/<YYYYMMDD>/ember-easyForm.js
<S3_FILE_PREFIX>/daily/<YYYYMMDD>/ember-easyForm.prod.js
<S3_FILE_PREFIX>/daily/<YYYYMMDD>/ember-easyForm.min.js
<S3_FILE_PREFIX>/shas/<SHA>/ember-easyForm.js
<S3_FILE_PREFIX>/shas/<SHA>/ember-easyForm.prod.js
<S3_FILE_PREFIX>/shas/<SHA>/ember-easyForm.min.js
```

The following secure environment values need to be added to
`.travis.yml`:
- S3_ACCESS_KEY_ID
- S3_SECRET_ACCESS_KEY
- S3_BUCKET_NAME - Pre-populated to `builds.dockyard.com`
- S3_FILE_PREFIX - Pre-populated to `ember-easyForm`

---

These can be added after merging this PR via the following commands:

``` sh
gem install travis
travis encrypt S3_ACCESS_KEY_ID=some-value-here --add
travis encrypt S3_SECRET_ACCESS_KEY=some-value-here --add
```
