### PR TITLE
Properly handle when context is the formForModel.

### DIFF
--- a/packages/ember-easyForm/lib/views/base_view.js
+++ b/packages/ember-easyForm/lib/views/base_view.js
@@ -16,7 +16,9 @@ Ember.EasyForm.BaseView = Ember.View.extend({
   formForModel: function(){
     var formForModelPath = this.get('templateData.keywords.formForModelPath');
 
-    if (formForModelPath) {
+    if (formForModelPath === 'context' || formForModelPath === 'controller' || formForModelPath === 'this') {
+      return this.get('context');
+    } else if (formForModelPath) {
       return this.get('context.' + formForModelPath);
     } else {
       return this.get('context');

--- a/packages/ember-easyForm/tests/helpers/form-for_test.js
+++ b/packages/ember-easyForm/tests/helpers/form-for_test.js
@@ -57,7 +57,7 @@ var append = function(view) {
 
 test('renders a form element', function() {
   view = Ember.View.create({
-    template: templateFor('{{#form-for model}}{{/form-for}}'),
+    template: templateFor('{{#form-for controller}}{{/form-for}}'),
     controller: controller
   });
   append(view);
@@ -67,7 +67,7 @@ test('renders a form element', function() {
 test('uses the defined wrapper', function() {
   Ember.EasyForm.Config.registerWrapper('my_wrapper', {formClass: 'my-form-class'});
   view = Ember.View.create({
-    template: templateFor('{{#form-for model wrapper="my_wrapper"}}{{/form-for}}'),
+    template: templateFor('{{#form-for controller wrapper="my_wrapper"}}{{/form-for}}'),
     controller: controller
   });
   append(view);
@@ -79,7 +79,7 @@ test('submitting with invalid model does not call submit action on controller', 
     set(model, 'isValid', false);
   });
   view = Ember.View.create({
-    template: templateFor('{{#form-for model}}{{/form-for}}'),
+    template: templateFor('{{#form-for controller}}{{/form-for}}'),
     container: container,
     controller: controller
   });
@@ -95,7 +95,7 @@ test('submitting with valid model calls submit action on controller', function()
     set(model, 'isValid', true);
   });
   view = Ember.View.create({
-    template: templateFor('{{#form-for model}}{{/form-for}}'),
+    template: templateFor('{{#form-for controller}}{{/form-for}}'),
     container: container,
     controller: controller
   });
@@ -118,7 +118,7 @@ test('submitting with valid controller calls submit action on controller', funct
     controller.set('isValid', true);
   });
   view = Ember.View.create({
-    template: templateFor('{{#form-for model}}{{/form-for}}'),
+    template: templateFor('{{#form-for controller}}{{/form-for}}'),
     container: container,
     controller: controller
   });
@@ -134,7 +134,7 @@ test('can override the action called by submit on the controller', function() {
     set(model, 'isValid', true);
   });
   view = Ember.View.create({
-    template: templateFor('{{#form-for model action="bigSubmit"}}{{/form-for}}'),
+    template: templateFor('{{#form-for controller action="bigSubmit"}}{{/form-for}}'),
     container: container,
     controller: controller
   });
@@ -151,7 +151,7 @@ test('submitting with model that does not have validate method', function() {
     controller.set('content', model);
   });
   view = Ember.View.create({
-    template: templateFor('{{#form-for model}}{{/form-for}}'),
+    template: templateFor('{{#form-for controller}}{{/form-for}}'),
     container: container,
     controller: controller
   });
@@ -168,7 +168,7 @@ test('submitting with ember-data model without validations can call submit actio
     model.validate = undefined;
   });
   view = Ember.View.create({
-    template: templateFor('{{#form-for model}}{{/form-for}}'),
+    template: templateFor('{{#form-for controller}}{{/form-for}}'),
     container: container,
     controller: controller
   });


### PR DESCRIPTION
When using `{{form-for controller}}` or `{{form-for this}}` we were 
incorrectly delegating to `context.controller` when in reality `context`
**is** the controller.
