### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ be used as blocks such as:
 {{#input firstName}}
   {{input-field firstName}}{{label-field firstName}}
   <br/>
-  {{error-field firstName}}
+  {{#if view.showError}}{{error-field firstName}}{{/if}}
 {{/input}}
 ```
 


### PR DESCRIPTION
This matches the example input block's displaying error behavior to the standard input helper. That is: to hide errors until a focus-out occurs. 

The example for input block currently is confusing to those expecting a default user experience.