### PR TITLE
support the 'content' attribute for input as="select"

### DIFF
--- a/packages/ember-easyForm/lib/views/input.js
+++ b/packages/ember-easyForm/lib/views/input.js
@@ -29,7 +29,7 @@ Ember.EasyForm.Input = Ember.EasyForm.BaseView.extend({
     this.set(name+'.for', this.get('input-field-'+this.elementId+'.elementId'));
   },
   concatenatedProperties: ['inputOptions', 'bindableInputOptions'],
-  inputOptions: ['as', 'collection', 'optionValuePath', 'optionLabelPath', 'selection', 'value', 'multiple', 'name'],
+  inputOptions: ['as', 'collection', 'content', 'optionValuePath', 'optionLabelPath', 'selection', 'value', 'multiple', 'name'],
   bindableInputOptions: ['placeholder', 'prompt', 'disabled'],
   defaultOptions: {
     name: function(){


### PR DESCRIPTION
The input view does not support the passing of a content attribute as described in https://github.com/dockyard/ember-easyForm/issues/163

I'm proposing support of this so that I can pass a collection to my select input.