### PR TITLE
Fixes #171: Adds missing `optionGroupPath` to `inputOptions`

### DIFF
--- a/packages/ember-easyForm/lib/views/input.js
+++ b/packages/ember-easyForm/lib/views/input.js
@@ -29,7 +29,7 @@ Ember.EasyForm.Input = Ember.EasyForm.BaseView.extend({
     this.set(name+'.for', this.get('input-field-'+this.elementId+'.elementId'));
   },
   concatenatedProperties: ['inputOptions', 'bindableInputOptions'],
-  inputOptions: ['as', 'collection', 'optionValuePath', 'optionLabelPath', 'selection', 'value', 'multiple', 'name'],
+  inputOptions: ['as', 'collection', 'optionValuePath', 'optionLabelPath', 'optionGroupPath', 'selection', 'value', 'multiple', 'name'],
   bindableInputOptions: ['placeholder', 'prompt', 'disabled'],
   defaultOptions: {
     name: function(){


### PR DESCRIPTION
As noted in #171 `Ember.EasyForm.Input.inputOptions` is missing the `optionGroupPath` option for `Ember.Select`. This PR Fixes #171 by adding the option to the array.