### PR TITLE
Hash helper `{{#form-for model as |f|}}`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-release
-  - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
+  # - EMBER_TRY_SCENARIO=ember-release
+  # - EMBER_TRY_SCENARIO=ember-beta
+  # - EMBER_TRY_SCENARIO=ember-canary
 
 matrix:
   fast_finish: true

--- a/addon/components/form-for.js
+++ b/addon/components/form-for.js
@@ -7,6 +7,8 @@ var FormFormComponent = Ember.Component.extend(WrapperMixin, {
   classNameBindings: ['wrapperConfig.formClass'],
   novalidate: 'novalidate',
   wrapper: 'default',
+  layoutName: Ember.computed.oneWay('wrapperConfig.formTemplate'),
+
 
   init: function() {
     this._super(...arguments);

--- a/addon/components/internal-input-for.js
+++ b/addon/components/internal-input-for.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import WrapperMixin from 'ember-easy-form/wrapper-mixin';
 import {humanize} from 'ember-easy-form/utilities';
+import {assign} from 'ember-easy-form/utilities';
 
 const PropertyNameNotDefinedMessage = 'Please, define the property name. ' +
   'You probably forgot to quote the property name in some `input-for` component.';
@@ -88,6 +89,20 @@ var FormInputComponent = Ember.Component.extend(WrapperMixin, {
     this.set('hasFocusedOut', true);
     this.showValidationError();
   },
+  inputOptions: Ember.computed('savedInputOptions', 'attrs', function() {
+    var inputOptions = this.get('savedInputOptions');
+    if (!inputOptions) {
+      // Move all values to the `inputOptions` hash, except the ones we use in the `internal-input-for`
+      inputOptions = assign({}, this.get('attrs'));
+      for(let i=0; i<knownProperties.length; i++) {
+        const key = knownProperties[i];
+        if (inputOptions.hasOwnProperty(key)) {
+          delete inputOptions[key];
+        }
+      }
+    }
+    return inputOptions;
+  }),
   showValidationError: function() {
     if (this.get('hasFocusedOut')) {
       var property = this.get('propertyName');

--- a/addon/config.js
+++ b/addon/config.js
@@ -10,6 +10,7 @@ export default {
       hintClass: 'hint',
       labelClass: '',
       submitClass: '',
+      formTemplate: 'components/easy-form/form',
       inputTemplate: 'components/easy-form/input-for',
       errorTemplate: 'components/easy-form/error-field',
       labelTemplate: 'components/easy-form/label-field',

--- a/addon/keywords/input-for.js
+++ b/addon/keywords/input-for.js
@@ -14,7 +14,7 @@ export default {
       }
     }
 
-    customHash.inputOptions = inputOptions;
+    customHash.savedInputOptions = inputOptions;
     return assign({}, state, { customHash: customHash });
   },
 

--- a/app/templates/components/easy-form/form.hbs
+++ b/app/templates/components/easy-form/form.hbs
@@ -1,0 +1,1 @@
+{{yield (hash input=(component "internal-input-for"))}}

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-easy-form",
   "dependencies": {
-    "ember": "1.13.11",
+    "ember": "components/ember#2.3.0-beta.3",
     "ember-cli-shims": "0.0.6",
     "ember-cli-test-loader": "0.2.1",
     "ember-load-initializers": "0.1.7",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-easy-form",
   "dependencies": {
-    "ember": "components/ember#2.3.0-beta.3",
+    "ember": "components/ember#canary",
     "ember-cli-shims": "0.0.6",
     "ember-cli-test-loader": "0.2.1",
     "ember-load-initializers": "0.1.7",
@@ -11,5 +11,8 @@
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0"
+  },
+  "resolutions": {
+    "ember": "canary"
   }
 }

--- a/tests/dummy/app/templates/person.hbs
+++ b/tests/dummy/app/templates/person.hbs
@@ -1,10 +1,12 @@
 <h2>Person form</h2>
 <div id="teste">
-{{#form-for model}}
-  {{input-for "firstName"}}
-  {{input-for "lastName"}}
+
+{{#form-for model as |f|}}
+  {{f.input "firstName"}}
+  {{f.input "lastName"}}
   <input type="submit">
 {{/form-for}}
+
 
 <p class="bound-values">
   First name: <span class="first-name">{{model.firstName}}</span><br>


### PR DESCRIPTION
The future is here! :fireworks:

**Please, don't merge this PR!!**

This is a test using the new hash helper available on Ember 2.3. As you can see, it is very simple to support the new syntax.

``` hbs
{{#form-for model as |f|}}
  {{f.input "firstName"}}
  {{f.input "lastName"}}
   <input type="submit">
 {{/form-for}}
```
