### PR TITLE
Fix label losing "for" attribute and deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - EMBER_TRY_SCENARIO=default
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
+  - ALLOW_DEPRECATIONS=true EMBER_TRY_SCENARIO=ember-canary
 
 matrix:
   fast_finish: true

--- a/addon/components/internal-input-for.js
+++ b/addon/components/internal-input-for.js
@@ -67,7 +67,7 @@ var FormInputComponent = Ember.Component.extend(WrapperMixin, {
   tagName: 'div',
   classNames: ['string'],
   classNameBindings: ['wrapperConfig.inputClass', 'propertyName'],
-  didInsertElement: function() {
+  didRender: function() {
     var labelComponent, inputComponent;
 
     this.forEachChildView((view) => {
@@ -81,7 +81,9 @@ var FormInputComponent = Ember.Component.extend(WrapperMixin, {
 
     if (labelComponent && inputComponent) {
       // This is not the best way to do it. We should not change the element after it was created.
-      labelComponent.set('for', Ember.get(inputComponent, 'elementId'));
+      Ember.run.scheduleOnce('afterRender', this, function() {
+        labelComponent.set('for', Ember.get(inputComponent, 'elementId'));
+      });
     }
   },
   focusOut: function() {

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0"
   }

--- a/tests/components/input-for-test.js
+++ b/tests/components/input-for-test.js
@@ -215,6 +215,23 @@ test('binds label to input field', function(assert) {
   assert.equal(input.prop('id'), label.prop('for'));
 });
 
+test('binds label to input field across re-rendering', function(assert) {
+  Ember.run(() => {
+    this.get('model.errors.firstName').pushObject("can't be blank");
+  });
+  this.render(hbs`{{#form-for model}}{{input-for "firstName"}}{{/form-for}}`);
+  var initialInput = this.$().find('input');
+  var initialLabel = this.$().find('label');
+  assert.equal(initialInput.prop('id'), initialLabel.prop('for'));
+  Ember.run(() => {
+    this.$().find('input').blur();
+  });
+  var reRenderedInput = this.$().find('input');
+  var reRenderedLabel = this.$().find('label');
+  assert.notEqual(initialInput.prop('id'), reRenderedInput.prop('id'));
+  assert.equal(reRenderedInput.prop('id'), reRenderedLabel.prop('for'));
+});
+
 test('uses the wrapper config', function(assert) {
   config.registerWrapper('my_wrapper', {inputClass: 'my-input', errorClass: 'my-error', fieldErrorClass: 'my-fieldWithErrors'});
 

--- a/tests/components/input-for-test.js
+++ b/tests/components/input-for-test.js
@@ -261,7 +261,7 @@ test('sets input attributes property as bindings', function(assert) {
     label: 'My label',
     hint: 'Some hint'
   });
-  this.render(hbs`{{#form-for model}}{{input-for "firstName" placeholderBinding="placeholder" labelBinding="label" hintBinding="hint"}}{{/form-for}}`);
+  this.render(hbs`{{#form-for model}}{{input-for "firstName" placeholder=placeholder label=label hint=hint}}{{/form-for}}`);
   assert.equal(this.$().find('input').prop('placeholder'), 'The placeholder');
   assert.equal(this.$().find('label').text(), 'My label');
   assert.equal(this.$().find('.hint').text(), 'Some hint');

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -37,6 +37,8 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     ENV.APP.rootElement = '#ember-testing';
+
+    ENV.EmberENV.RAISE_ON_DEPRECATION = !process.env['ALLOW_DEPRECATIONS'];
   }
 
   if (environment === 'production') {


### PR DESCRIPTION
This is for the 1.0 branch (which looks great, by the way).

When the input was re-rendered, the label's `for` attribute would disappear (since the underlying elements all change). This is solved by switching from `didInsertElement` (called only once as of Ember 1.13) to `didRender` (called on re-renders too).
    
This also fixes a deprecation warning present due to the `for` attribute being modified during this rendering phase by shifting it to the `afterRender` callback.

I'm still not sure changing the element's `for` attribute after rendering is ideal (as the comment already noted), but I'm not entirely sure how else to go about this.

This also includes a couple of other small things I ran into while testing this, but let me know if you'd prefer for any of this to be split out into separate pull requests:

- Locking jQuery to 1.11.3, since running ember tests would otherwise hang on a fresh installation due to jQuery 1.12 being installed: https://github.com/ember-cli/ember-cli/issues/5317
- Raising exceptions during tests for any Ember deprecations (so I could ensure the `afterRender` fix would indeed do the trick). I also needed to fix the template used in one other test to get rid of deprecation warnings about the binding syntax in Ember 1.13+.